### PR TITLE
Updates portfolio for container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:3.3.0
+
+WORKDIR /site
+COPY Gemfile /site/
+# COPY Gemfile.lock /site/
+
+RUN bundle install
+
+CMD ["bash"]

--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,17 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "3.9"
+gem "jekyll", "~> 4.3.3"
 
 # This is the default theme.
 gem "agency-jekyll-theme"
 gem "kramdown-parser-gfm"
 gem "webrick"
+
+gem "csv"
+gem "base64"
+gem "bigdecimal"
+gem "logger"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
@@ -25,3 +30,4 @@ gem "webrick"
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
 end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,73 +4,88 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     agency-jekyll-theme (1.0.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.5)
+    csv (3.3.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
+    google-protobuf (4.29.3-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
     http_parser.rb (0.8.0)
-    i18n (0.9.5)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (3.9.0)
+    jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (~> 0.7)
-      jekyll-sass-converter (~> 1.0)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
-      kramdown (>= 1.17, < 3)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.3.3)
+      mercenary (>= 0.3.6, < 0.5)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
+      rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-sass-converter (1.5.2)
-      sass (~> 3.4)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    mercenary (0.3.6)
+    logger (1.6.5)
+    mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
-    rouge (3.30.0)
+    rexml (3.4.0)
+    rouge (4.5.1)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    webrick (1.9.0)
+    sass-embedded (1.83.4-x86_64-linux-gnu)
+      google-protobuf (~> 4.29)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
 
 PLATFORMS
-  x86_64-darwin-22
+  x86_64-linux-gnu
 
 DEPENDENCIES
   agency-jekyll-theme
-  jekyll (= 3.9)
+  base64
+  bigdecimal
+  csv
+  jekyll (~> 4.3.3)
   jekyll-feed (~> 0.6)
   kramdown-parser-gfm
+  logger
   webrick
 
 RUBY VERSION
-   ruby 3.2.0p0
+   ruby 3.3.0p0
 
 BUNDLED WITH
-   2.4.2
+   2.5.3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+container:
+	docker build -t portfolio .
+
+build:
+	script/build
+
+serve:
+	script/server

--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ View this jekyll theme in action [here](https://y7kim.github.io/agency-jekyll-th
 
 =========
 For more details, read [documentation](http://jekyllrb.com/)
+
+# Containerized
+
+`make container` to build the build container
+
+All builds/work happens inside this container. It is frozen at Ruby 3.3 for compatibility reasons. 
+
+The `Gemfile.lock` is generated as part of the build process. It may be, at some point, that deleting the `Gemfile.lock` and then rerunning `make container ; make build` is a Good Thing.
+
+`make build` to build the site
+
+This should build the site, leaving everything in `_site`
+
+`make serve` to serve it locally at :4000
+
+This should build the site and launch a preview you can reach at 
+
+http://localhost:4000/
+
+

--- a/script/app-env
+++ b/script/app-env
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e # always good practice!
+
+# run what we were asked to if we're already inside the container
+[ -f /etc/inside-container ] && exec "$@"
+
+# otherwise, re-exec the command inside the container
+root=$(realpath "$(dirname "$0")/..")
+exec docker run -it --rm \
+  -p 4000:4000 \
+  -v "$root:/site" \
+  portfolio "$@"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,1 @@
+docker build -t portfolio .

--- a/script/build
+++ b/script/build
@@ -1,0 +1,1 @@
+script/app-env bundle exec jekyll build

--- a/script/server
+++ b/script/server
@@ -1,0 +1,2 @@
+script/app-env bundle exec jekyll serve \
+  --incremental --drafts --host 0.0.0.0


### PR DESCRIPTION
This should keep all of the Ruby stuff inside of Docker containers, so that platform-specific issues won't matter.

The README is updated to include the commands you would want to run for a containerized build. I'm not sure if you're on a Windows or Mac, so the process may look a bit different, depending. This was developed/tested under Linux, so some back-and-forth might be needed before things are good to go.

1. Install Docker.
2. If you're on a Mac, you should be able to follow the `README.md`
3. If you're on Windows... we may have to modify the process

Essentially, the steps are:

1. Build the container
2. Run `script/build`

or

2. Run `script/server`

Where `build` is actually

```
docker run -it --rm \
  -p 4000:4000 \
  -v "$root:/site" \
  portfolio "$@" \
  bundle exec jekyll build
```

and `server` is actually

```
docker run -it --rm \
  -p 4000:4000 \
  -v "$root:/site" \
  portfolio "$@" \
  bundle exec jekyll serve \
  --incremental --drafts --host 0.0.0.0
```

Hence... it's a bit cleaner if it is on Linux/Mac. On Windows... you either need to copy-paste the docker commands (and maybe put them in a PowerShell script?), or have the WSL2 environment (a Linux environment) to run the build. 